### PR TITLE
Proper conversion to/from JS when issuing queries to Cassandra

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -122,11 +122,7 @@ DB.prototype._get = function (keyspace, req, consistency, table, schema) {
         var rows = [];
         result.rows.forEach(function(row) {
             // Apply value conversions
-            for (var att in row) {
-                if (row[att] && schema.conversions[att] && schema.conversions[att].read) {
-                    row[att] = schema.conversions[att].read(row[att]);
-                }
-            }
+            dbu.convertRow(row, schema);
             // Filter rows that don't match any more
             // XXX: Refine this for queries in the past:
             // - compare to query time for index entries

--- a/lib/db.js
+++ b/lib/db.js
@@ -524,18 +524,38 @@ DB.prototype._delete = function (keyspace, req, consistency, table) {
         + cassID(keyspace) + '.' + cassID(table);
 
     var params = [];
+    var paramKeys = [];
     // Build up the condition
     if (req.attributes) {
         cql += ' where ';
         var condResult = dbu.buildCondition(req.attributes);
         cql += condResult.query;
         params = condResult.params;
+        paramKeys = condResult.keys;
     }
 
     // TODO: delete from indexes too!
     //console.log(cql, params);
-    return this.client.execute_p(cql, params,
-            {consistency: consistency, prepare: true});
+    if (!params.length || this.schemaCache[keyspace]) {
+        // we either have no parameters to convert, or the schema
+        // is cached, so we can convert the params and execute
+        // the query immediately
+        return this.client.execute_p(cql,
+                dbu.convertParams(this.schemaCache[keyspace], paramKeys, params),
+                {consistency: consistency, prepare: true});
+    } else {
+        // the schema is not cached, but we have parameters to
+        // convert, so we need to fetch the schema first, and
+        // later convert the values and execute the deletion
+        var self = this;
+        return this._getSchema(keyspace, this.defaultConsistency)
+            .then(function(schema) {
+                self.schemaCache[keyspace] = schema;
+                return self.client.execute_p(cql,
+                        dbu.convertParams(schema, paramKeys, params),
+                        {consistency: consistency, prepare: true});
+            });
+    }
 };
 
 DB.prototype.createTable = function (reverseDomain, req) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -226,7 +226,7 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
     };
 
     var internalColumns = {
-        _deleted: true,
+        _del: true,
         _tid: true
     };
 
@@ -243,7 +243,7 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
     }
 
     var buildResult = dbu.buildGetQuery(keyspace, newIndexReq, consistency,
-            table, this.schemaCache[keyspace]);
+            table, cachedSchema);
 
     var self = this;
     var queries = [];

--- a/lib/db.js
+++ b/lib/db.js
@@ -23,32 +23,6 @@ function DB (client, options) {
     this.schemaCache = {};
 }
 
-function convert(value, fn) {
-    if (value === null || value.constructor !== Object) {
-        return fn(value);
-    } else {
-        var predKeys = Object.keys(value);
-        if (predKeys.length === 1) {
-            var predOp = predKeys[0];
-            var predArg = value[predOp];
-            switch (predOp.toLowerCase()) {
-                case 'eq':
-                case 'lt':
-                case 'gt':
-                case 'le':
-                case 'ge':
-                case 'ne': value[predOp] = fn(predArg); break;
-                case 'between': value[predOp] = [fn(predArg[0]), fn(predArg[1])];
-                                break;
-                default: throw new Error ('Operator ' + predOp + ' not supported!');
-            }
-            return value;
-        } else {
-            throw new Error ('Invalid predicate ' + JSON.stringify(value));
-        }
-    }
-}
-
 // Info table schema
 DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
     table: 'meta',
@@ -133,16 +107,6 @@ DB.prototype._get = function (keyspace, req, consistency, table, schema) {
                 + ', table: ' + table);
     }
 
-    // Apply value conversions
-    if (req.attributes && schema.conversions) {
-        schema.conversions.write.forEach(function(conv) {
-            var val = req.attributes[conv.att];
-            if (val) {
-                req.attributes[conv.att] = convert(val, conv.fn);
-            }
-        });
-    }
-
     if (!schema.iKeyMap) {
         self.log('error/cassandra/no_iKeyMap', schema);
     }
@@ -158,13 +122,11 @@ DB.prototype._get = function (keyspace, req, consistency, table, schema) {
         var rows = [];
         result.rows.forEach(function(row) {
             // Apply value conversions
-            schema.conversions.read.forEach(function(conv) {
-                var val = row[conv.att];
-                if (val) {
-                    row[conv.att] = conv.fn(val);
+            for (var att in row) {
+                if (row[att] && schema.conversions[att] && schema.conversions[att].read) {
+                    row[att] = schema.conversions[att].read(row[att]);
                 }
-            });
-
+            }
             // Filter rows that don't match any more
             // XXX: Refine this for queries in the past:
             // - compare to query time for index entries
@@ -371,17 +333,6 @@ DB.prototype._put = function(keyspace, req, consistency, table ) {
 
     if (!req.attributes[schema.tid]) {
         req.attributes[schema.tid] = uuid.v1();
-    }
-
-
-    // Apply value conversions
-    if (schema.conversions) {
-        schema.conversions.write.forEach(function(conv) {
-            var val = req.attributes[conv.att];
-            if (val) {
-                req.attributes[conv.att] = conv.fn(val);
-            }
-        });
     }
 
     req.timestamp = uuid.v1time(req.attributes[schema.tid]);

--- a/lib/db.js
+++ b/lib/db.js
@@ -152,6 +152,11 @@ DB.prototype._getSecondaryIndex = function(keyspace, req, consistency, table, bu
     .then(function(results) {
         var queries = [];
         var cachedSchema = self.schemaCache[keyspace];
+        
+        // convert the result values
+        results.rows.forEach(function (row) {
+            dbu.convertRow(row, cachedSchema);
+        });
 
         var newReq = {
             table: table,
@@ -180,7 +185,7 @@ DB.prototype._getSecondaryIndex = function(keyspace, req, consistency, table, bu
             var finalRows = [];
             batchResults.forEach(function(item){
                 if (finalRows.length < req.limit) {
-                    finalRows.push(item.rows[0]);
+                    finalRows.push(dbu.convertRow(item.rows[0], cachedSchema));
                 }
             });
             return [finalRows, results.rows[rowno]];
@@ -225,7 +230,6 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
         _tid: true
     };
 
-
     var cachedSchema = this.schemaCache[keyspace].secondaryIndexes[req.index];
     for(var item in startKey) {
         if ( !internalColumns[item] && cachedSchema._attributeIndexes[item]) {
@@ -239,7 +243,7 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
     }
 
     var buildResult = dbu.buildGetQuery(keyspace, newIndexReq, consistency,
-            table, cachedSchema);
+            table, this.schemaCache[keyspace]);
 
     var self = this;
     var queries = [];
@@ -254,8 +258,8 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
                         consistency: consistency
                     })
         .on('readable', function(){
-            var row = this.read();
-            for (row; row !== null; row=this.read()) {
+            var row = dbu.convertRow(this.read(), cachedSchema);
+            for (row; row !== null; row=dbu.convertRow(this.read(), cachedSchema)) {
                 lastrow = row;
                 var attributes = {};
                 var proj = {};
@@ -276,7 +280,7 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
                             item.options || {consistency: consistency, prepare: true})
                     .then(function(results){
                         if (finalRows.length < req.limit) {
-                            finalRows.push(results.rows[0]);
+                            finalRows.push(dbu.convertRow(results.rows[0], cachedSchema));
                         }
                     });
                 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -462,7 +462,7 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
             for (var i = res.items.length - 1; i >= 0; i--) {
                 // Process rows in reverse chronological order
                 var row = res.items[i];
-                newerRebuilder.handleRow(null, row);
+                newerRebuilder.handleRow(null, row, true);
             }
         });
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -434,9 +434,6 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
     for (var key in req.attributes) {
         var val = req.attributes[key];
         if (val !== undefined && schema.attributes[key]) {
-            if (val && val.constructor === Object) {
-                val = JSON.stringify(val);
-            }
             if (!schema.iKeyMap[key]) {
                 keys.push(key);
                 params.push(val);

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -275,6 +275,15 @@ function identityConversion (val) {
     return val;
 }
 
+dbu.conversions = {
+    'int': { write: codec.encodeVarInt, read: codec.decodeVarInt },
+    varint: { write: codec.encodeVarInt, read: codec.decodeVarInt },
+    decimal: { write: codec.encodeDecimal, read: codec.decodeDecimal },
+    timestamp: { write: encodeTimestamp, read: decodeTimestamp },
+    json: { write: JSON.stringify, read: JSON.parse },
+    blob: { write: encodeBlob, read: identityConversion }
+};
+
 /*
  * Derive additional schema info from the public schema
  */
@@ -290,28 +299,12 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
     var lastElem = schema.index[schema.index.length - 1];
     var lastKey = lastElem.attribute;
 
-    psi.conversions = {};
     // Extract attributes that need conversion in the read or write path
+    psi.conversions = {};
     for (var att in psi.attributes) {
-        switch (psi.attributes[att]) {
-        case 'varint':
-        case 'int':
-            psi.conversions[att] = { write: codec.encodeVarInt, read: codec.decodeVarInt };
-            break;
-        case 'decimal':
-            psi.conversions[att] = { write: codec.encodeDecimal, read: codec.decodeDecimal };
-            break;
-        case 'timestamp':
-            psi.conversions[att] = { write: encodeTimestamp, read: decodeTimestamp };
-            break;
-        case 'json':
-            psi.conversions[att] = { write: JSON.stringify, read: JSON.parse };
-            break;
-        case 'blob':
-            psi.conversions[att] = { write: encodeBlob, read: identityConversion };
-            break;
-        default:
-            break;
+        var type = psi.attributes[att];
+        if (dbu.conversions[type]) {
+            psi.conversions[att] = dbu.conversions[type];
         }
     }
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -270,6 +270,11 @@ function decodeTimestamp (ts) {
     return new Date(ts).toISOString();
 }
 
+// Simple identity function for values that do not need conversion
+function identityConversion (val) {
+    return val;
+}
+
 /*
  * Derive additional schema info from the public schema
  */
@@ -285,32 +290,25 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
     var lastElem = schema.index[schema.index.length - 1];
     var lastKey = lastElem.attribute;
 
-    psi.conversions = {
-        write: [],
-        read: []
-    };
+    psi.conversions = {};
     // Extract attributes that need conversion in the read or write path
     for (var att in psi.attributes) {
         switch (psi.attributes[att]) {
         case 'varint':
         case 'int':
-            psi.conversions.write.push({ att: att, fn: codec.encodeVarInt });
-            psi.conversions.read.push({ att: att, fn: codec.decodeVarInt });
+            psi.conversions[att] = { write: codec.encodeVarInt, read: codec.decodeVarInt };
             break;
         case 'decimal':
-            psi.conversions.write.push({ att: att, fn: codec.encodeDecimal });
-            psi.conversions.read.push({ att: att, fn: codec.decodeDecimal });
+            psi.conversions[att] = { write: codec.encodeDecimal, read: codec.decodeDecimal };
             break;
         case 'timestamp':
-            psi.conversions.write.push({ att: att, fn: encodeTimestamp });
-            psi.conversions.read.push({ att: att, fn: decodeTimestamp });
+            psi.conversions[att] = { write: encodeTimestamp, read: decodeTimestamp };
             break;
         case 'json':
-            psi.conversions.write.push({ att: att, fn: JSON.stringify });
-            psi.conversions.read.push({ att: att, fn: JSON.parse });
+            psi.conversions[att] = { write: JSON.stringify, read: JSON.parse };
             break;
         case 'blob':
-            psi.conversions.write.push({ att: att, fn: encodeBlob });
+            psi.conversions[att] = { write: encodeBlob, read: identityConversion };
             break;
         default:
             break;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -358,6 +358,33 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
     return psi;
 };
 
+/* 
+ * Converts query parameters from JS object/values into
+ * serializable Cassandra values (based on schema.conversions)
+ *
+ * @param {Schema} schema the schema to consult for conversion methods
+ * @param {Array} keys the list of parameter keys to look up in the schema for conversion
+ * @param {Array} params the parameter values to convert
+ * @returns {Array} a new array containing converted values, or the original params array if nothing has been done
+ */
+dbu.convertParams = function convertParams (schema, keys, params) {
+    var converted = [];
+    if (!(schema && schema.conversions && keys && params && keys.length)) {
+        return params;
+    }
+    if(keys.length !== params.length) {
+        throw new Error('dbu.convertParams(): keys and params arrays are of different sizes!');
+    }
+    var convObj = schema.conversions;
+    keys.forEach(function (key, idx, arr) {
+        if(key && convObj[key] && convObj[key].write && params[idx]) {
+            converted.push(convObj[key].write(params[idx]));
+        } else {
+            converted.push(params[idx]);
+        }
+    });
+    return converted;
+};
 
 
 /*
@@ -366,6 +393,7 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
 
 dbu.buildCondition = function buildCondition (pred) {
     var params = [];
+    var keys = [];
     var conjunctions = [];
     for (var predKey in pred) {
         var cql = '';
@@ -378,22 +406,22 @@ dbu.buildCondition = function buildCondition (pred) {
             // Default to equality
             cql += ' = ?';
             params.push(predObj);
+            keys.push(predKey);
         } else {
             var predKeys = Object.keys(predObj);
             if (predKeys.length === 1) {
                 var predOp = predKeys[0];
                 var predArg = predObj[predOp];
                 switch (predOp.toLowerCase()) {
-                case 'eq': cql += ' = ?'; params.push(predArg); break;
-                case 'lt': cql += ' < ?'; params.push(predArg); break;
-                case 'gt': cql += ' > ?'; params.push(predArg); break;
-                case 'le': cql += ' <= ?'; params.push(predArg); break;
-                case 'ge': cql += ' >= ?'; params.push(predArg); break;
-                // Also support 'neq' for symmetry with 'eq' ?
-                case 'ne': cql += ' != ?'; params.push(predArg); break;
+                case 'eq': cql += ' = ?'; params.push(predArg); keys.push(predKey); break;
+                case 'lt': cql += ' < ?'; params.push(predArg); keys.push(predKey); break;
+                case 'gt': cql += ' > ?'; params.push(predArg); keys.push(predKey); break;
+                case 'le': cql += ' <= ?'; params.push(predArg); keys.push(predKey); break;
+                case 'ge': cql += ' >= ?'; params.push(predArg); keys.push(predKey); break;
+                case 'ne': cql += ' != ?'; params.push(predArg); keys.push(predKey); break;
                 case 'between':
-                        cql += ' >= ?' + ' AND '; params.push(predArg[0]);
-                        cql += dbu.cassID(predKey) + ' <= ?'; params.push(predArg[1]);
+                        cql += ' >= ?' + ' AND '; params.push(predArg[0]); keys.push(predKey);
+                        cql += dbu.cassID(predKey) + ' <= ?'; params.push(predArg[1]); keys.push(predKey);
                         break;
                 default: throw new Error ('Operator ' + predOp + ' not supported!');
                 }
@@ -405,6 +433,7 @@ dbu.buildCondition = function buildCondition (pred) {
     }
     return {
         query: conjunctions.join(' AND '),
+        keys: keys,
         params: params
     };
 };
@@ -429,6 +458,7 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
     });
 
     var keys = [];
+    var paramKeys = [];
     var params = [];
     var placeholders = [];
     for (var key in req.attributes) {
@@ -437,6 +467,7 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
             if (!schema.iKeyMap[key]) {
                 keys.push(key);
                 params.push(val);
+                paramKeys.push(key);
             }
             placeholders.push('?');
         }
@@ -444,9 +475,11 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
 
     var using = '';
     var usingParams = [];
+    var usingParamsKeys = [];
     if (req.timestamp && !req.if) {
         using = ' USING TIMESTAMP ? ';
         usingParams.push(cass.types.Long.fromNumber(Math.round(req.timestamp * 1000)));
+        usingParamsKeys.push(null);
     }
 
     // switch between insert & update / upsert
@@ -474,13 +507,16 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
                 + ' (' + proj + ') values (';
         cql += placeholders.join(',') + ')' + cond + using;
         params = condRes.params.concat(params, usingParams);
+        paramKeys = condRes.keys.concat(paramKeys, usingParamsKeys);
     } else if ( keys.length ) {
         var condParams = [];
+        var condParamKeys = [];
         if (req.if) {
             cond = ' if ';
             condResult = dbu.buildCondition(req.if);
             cond += condResult.query;
             condParams = condResult.params;
+            condParamKeys = condResult.keys;
         }
 
         var updateProj = keys.map(dbu.cassID).join(' = ?,') + ' = ? ';
@@ -488,12 +524,13 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
                + using + ' set ' + updateProj + ' where ';
         cql += condRes.query + cond;
         params = usingParams.concat(params, condRes.params, condParams);
+        paramKeys = usingParamsKeys.concat(paramKeys, condRes.keys, condParamKeys);
 
     } else {
         throw new Error("Can't Update or Insert");
     }
 
-    return {query: cql, params: params};
+    return {query: cql, params: dbu.convertParams(schema, paramKeys, params)};
 };
 
 dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
@@ -542,12 +579,14 @@ dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
         + dbu.cassID(keyspace) + '.' + dbu.cassID(table);
 
     var params = [];
+    var paramKeys = [];
     // Build up the condition
     if (req.attributes) {
         cql += ' where ';
         var condResult = dbu.buildCondition(req.attributes);
         cql += condResult.query;
         params = condResult.params;
+        paramKeys = condResult.keys;
     }
 
     if (req.order) {
@@ -596,7 +635,7 @@ dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
         cql += ' limit ' + req.limit;
     }
 
-    return {query: cql, params: params};
+    return {query: cql, params: dbu.convertParams(schema, paramKeys, params)};
 };
 
 module.exports = dbu;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -248,7 +248,17 @@ dbu.makeIndexSchema = function makeIndexSchema (dataSchema, indexName) {
         s.attributes[tidKey] = dataSchema.attributes[tidKey];
         s.tid = tidKey;
     }
-
+    
+    // include the orignal schema's conversion table
+    s.conversions = {};
+    if (dataSchema.conversions) {
+        for (var attr in s.attributes) {
+            if (dataSchema.conversions[attr]) {
+                s.conversions[attr] = dataSchema.conversions[attr];
+            }
+        }
+    }
+    
     s.attributes._del = 'timeuuid';
 
     return s;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -386,6 +386,24 @@ dbu.convertParams = function convertParams (schema, keys, params) {
     return converted;
 };
 
+/**
+ * Converts a result row from Cassandra to JS values
+ *
+ * @param {Row} row the result row to convert; modified in place
+ * @param {Schema} schema the schema to use for conversion
+ * @returns {Row} the row with converted attribute values
+ */
+dbu.convertRow = function convertRow (row, schema) {
+    if (!(row && schema && schema.conversions)) {
+        return row;
+    }
+    for (var att in row) {
+        if (row[att] && schema.conversions[att] && schema.conversions[att].read) {
+            row[att] = schema.conversions[att].read(row[att]);
+        }
+    }
+    return row;
+}
 
 /*
  * # Section 3: CQL query generation

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -403,7 +403,7 @@ dbu.convertRow = function convertRow (row, schema) {
         }
     }
     return row;
-}
+};
 
 /*
  * # Section 3: CQL query generation

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -275,6 +275,26 @@ function identityConversion (val) {
     return val;
 }
 
+/**
+ * Generates read/write conversion functions for set-typed attributes
+ *
+ * @param {Object} convObj the conversion object to use for individual values (from dbu.conversions)
+ * @returns {Object} an object with 'read' and 'write' attributes
+ */
+function generateSetConvertor (convObj) {
+    if (!convObj) {
+        return { write: identityConversion, read: identityConversion };
+    }
+    return {
+        write: function (valArray) {
+            return valArray.map(convObj.write);
+        },
+        read: function (valArray) {
+            return valArray.map(convObj.read);
+        }
+    };
+}
+
 dbu.conversions = {
     'int': { write: codec.encodeVarInt, read: codec.decodeVarInt },
     varint: { write: codec.encodeVarInt, read: codec.decodeVarInt },
@@ -303,7 +323,16 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
     psi.conversions = {};
     for (var att in psi.attributes) {
         var type = psi.attributes[att];
-        if (dbu.conversions[type]) {
+        var set_type = /set<(\w+)>/.exec(type);
+        if (set_type) {
+            // this is a set-typed attribute
+            type = set_type[1];
+            // generate the convertors only if the underlying type has them defined
+            if (dbu.conversions[type]) {
+                psi.conversions[att] = generateSetConvertor(dbu.conversions[type]);
+            }
+        } else if (dbu.conversions[type]) {
+            // this is regular type and conversion methods are defined for it
             psi.conversions[att] = dbu.conversions[type];
         }
     }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -418,6 +418,7 @@ dbu.buildCondition = function buildCondition (pred) {
                 case 'gt': cql += ' > ?'; params.push(predArg); keys.push(predKey); break;
                 case 'le': cql += ' <= ?'; params.push(predArg); keys.push(predKey); break;
                 case 'ge': cql += ' >= ?'; params.push(predArg); keys.push(predKey); break;
+                case 'neq':
                 case 'ne': cql += ' != ?'; params.push(predArg); keys.push(predKey); break;
                 case 'between':
                         cql += ' >= ?' + ' AND '; params.push(predArg[0]); keys.push(predKey);

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -56,13 +56,9 @@ IndexRebuilder.prototype.diffRow = function (row) {
 
 
 IndexRebuilder.prototype.handleRow = function (n, row, converted) {
-    if (!converted && this.schema.conversions) {
+    if (!converted) {
         // the row is a raw return from Cassandra, convert the values
-        for (var attr in row) {
-            if (row[att] && this.schema.conversions[att]) {
-                row[att] = this.schema.conversions[att].read(row[att]);
-            }
-        }
+        dbu.convertRow(row, this.schema);
     }
     if (!this.prevRow) {
         // In normal operation there is no need to update the index for the

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -55,7 +55,15 @@ IndexRebuilder.prototype.diffRow = function (row) {
 };
 
 
-IndexRebuilder.prototype.handleRow = function (n, row) {
+IndexRebuilder.prototype.handleRow = function (n, row, converted) {
+    if (!converted && this.schema.conversions) {
+        // the row is a raw return from Cassandra, convert the values
+        for (var attr in row) {
+            if (row[att] && this.schema.conversions[att]) {
+                row[att] = this.schema.conversions[att].read(row[att]);
+            }
+        }
+    }
     if (!this.prevRow) {
         // In normal operation there is no need to update the index for the
         // first row, as we are only interested in diffs, and the new data was
@@ -111,7 +119,6 @@ IndexRebuilder.prototype.handleRow = function (n, row) {
             secondarySchema.iKeys.forEach(function(att) {
                 delReqAttributes[att] = row[att];
             });
-
             delReqAttributes._del = this.prevRow[this.schema.tid];
             var delReq = {
                 attributes: delReqAttributes,

--- a/test/index.js
+++ b/test/index.js
@@ -676,7 +676,9 @@ describe('DB backend', function() {
                         timeuuid: 'timeuuid',
                         uuid: 'uuid',
                         timestamp: 'timestamp',
-                        json: 'json'
+                        json: 'json',
+                        int_set: 'set<varint>',
+                        json_set: 'set<json>'
                     },
                     index: [
                         { attribute: 'string', type: 'hash' },
@@ -707,7 +709,13 @@ describe('DB backend', function() {
                         timestamp: '2014-11-14T19:10:40.912Z',
                         json: {
                             foo: 'bar'
-                        }
+                        },
+                        int_set: [123456, 2567, 598765],
+                        json_set: [
+                            {one: 1, two: 'two'},
+                            {foo: 'bar'},
+                            {test: [{a: 'b'}, 3]}
+                        ]
                     }
                 }
             })
@@ -736,7 +744,12 @@ describe('DB backend', function() {
                         timestamp: '2014-11-14T19:10:40.912Z',
                         json: {
                             foo: 'bar'
-                        }
+                        },
+                        int_set: [0, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+                        json_set: [
+                            {test: [{a: 'b'}, 3]},
+                            {another: 'string'}
+                        ]
                     }
                 }
             })
@@ -752,10 +765,12 @@ describe('DB backend', function() {
                     table: "typeTable",
                     proj: ['string','blob','set','int','varint', 'decimal',
                             'double','boolean','timeuuid','uuid',
-                            'timestamp','json']
+                            'timestamp','json', 'int_set', 'json_set']
                 }
             })
             .then(function(response){
+                // note: Cassandra orders sets, so the expected rows are
+                // slightly different than the original, supplied ones
                 deepEqual(response.body.items, [{
                     string: 'string',
                     blob: new Buffer('blob'),
@@ -771,7 +786,12 @@ describe('DB backend', function() {
                     timestamp: '2014-11-14T19:10:40.912Z',
                     json: {
                         foo: 'bar'
-                    }
+                    },
+                    int_set: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                    json_set: [
+                        {another: 'string'},
+                        {test: [{a: 'b'}, 3]}
+                    ]
                 },{
                     string: 'string',
                     blob: new Buffer('blob'),
@@ -787,7 +807,13 @@ describe('DB backend', function() {
                     timestamp: '2014-11-14T19:10:40.912Z',
                     json: {
                         foo: 'bar'
-                    }
+                    },
+                    int_set: [2567, 123456, 598765],
+                    json_set: [
+                        {foo: 'bar'},
+                        {one: 1, two: 'two'},
+                        {test: [{a: 'b'}, 3]}
+                    ]
                 }]);
             });
         });


### PR DESCRIPTION
Until now, values were only sporadically converted between rb-cassandra and Cassandra types. This PR resolves this, and systematically converts values from JS to Cassandra when issuing queries, and back to JS after fetching the result rows. It also introduces conversion schemes for set values whose underlying types need conversion (such as set<varint>, set<josn>, etc.).

This PR aims at resolving [T84900](https://phabricator.wikimedia.org/T84900)