### PR TITLE
Export the module_info property

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function RBCassandra (options) {
         module_info: {
             spec: null, // Re-export from spec module
             test: null, // Spec test function from spec module
-            dependencies: [],
+            dependencies: {},
             resources: [] // Dynamic resource dependencies, specific to implementation
         },
         createTable: this.createTable.bind(this),

--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ function RBCassandra (options) {
     this.setup = this.setup.bind(this);
     this.store = null;
     this.handler = {
+        module_info: {
+            spec: null, // Re-export from spec module
+            test: null, // Spec test function from spec module
+            dependencies: [],
+            resources: [] // Dynamic resource dependencies, specific to implementation
+        },
         createTable: this.createTable.bind(this),
         dropTable: this.dropTable.bind(this),
         get: this.get.bind(this),


### PR DESCRIPTION
Patch the export object of restbase-mod-table-cassandra to export the module_info property as well (albeit not containing any useful info for now).